### PR TITLE
Check value before accessing __isProxy.

### DIFF
--- a/observable-slim.js
+++ b/observable-slim.js
@@ -254,7 +254,7 @@ var ObservableSlim = (function() {
 				// if the value we're assigning is an object, then we want to ensure
 				// that we're assigning the original object, not the proxy, in order to avoid mixing
 				// the actual targets and proxies -- creates issues with path logging if we don't do this
-				if (value.__isProxy) value = value.__getTarget;
+				if (value && value.__isProxy) value = value.__getTarget;
 			
 				// was this change an original change or was it a change that was re-triggered below
 				var originalChange = true;


### PR DESCRIPTION
When trying to assign `null` value to the some field of nested object, `Cannot read property '__isProxy' of null` error is thrown.

Code that fails:
```
const ObservableSlim = require('observable-slim');

let fields = ObservableSlim.create({}, false, () => { });

fields.moreFields = {
  b: 123
};

fields.moreFields.b = null;
```
My change fixes this issue.