### PR TITLE
Check value before accessing __isProxy (2)

### DIFF
--- a/observable-slim.js
+++ b/observable-slim.js
@@ -366,7 +366,7 @@ var ObservableSlim = (function() {
 										var keys = Object.keys(target);
 										for (var i = 0, l = keys.length; i < l; i++) {
 											var property = keys[i];
-											if (target[property].__isProxy === true) {
+											if (target[property] && target[property].__isProxy === true) {
 												var nestedTarget = target[property].__getTarget;
 											} else {
 												var nestedTarget = target[property];


### PR DESCRIPTION
I'm getting a "Cannot read property '__isProxy' of undefined", when a value is being set to null. This issue seems to be similar to #17. This change fixes the issue.