### PR TITLE
Add a new __getPath property for fetching the path of a proxy

### DIFF
--- a/observable-slim.js
+++ b/observable-slim.js
@@ -157,6 +157,9 @@ var ObservableSlim = (function() {
 						parentPath.splice(-(i+1),(i+1));
 						return _getProperty(observable.parentProxy, parentPath.join("."));
 					}
+				} else if (property === "__getPath") {
+					var parentPath = _getPath(target, "__getParent");
+					return parentPath.slice(0, -12);
 				}
 
 				// for performance improvements, we assign this to a variable so we do not have to lookup the property value again


### PR DESCRIPTION
This pull request exposes the internal `_getPath` function as a `__getPath` property.

I built [a new library](https://github.com/dashersw/regie) based on observable-slim with the added functionality of watching for arbitrary references of proxies. While you're passing around parts of the original proxy, it helps to know the exact path to selectively subscribe to events.