### PR TITLE
Add parent path to changes map

### DIFF
--- a/observable-slim.js
+++ b/observable-slim.js
@@ -221,6 +221,7 @@ var ObservableSlim = (function() {
 				changes.push({
 					"type":"delete"
 					,"target":target
+                                        ,"parent":path.map(o => o.property).slice(1)
 					,"property":property
 					,"newValue":null
 					,"previousValue":previousValue[property]
@@ -298,6 +299,7 @@ var ObservableSlim = (function() {
 					changes.push({
 						"type":type
 						,"target":target
+                                                ,"parent":path.map(o => o.property).slice(1)
 						,"property":property
 						,"newValue":value
 						,"previousValue":receiver[property]


### PR DESCRIPTION
With an arbitrary set of object changes, including keys that contain dots or
slashes, it can be difficult to retrieve, via dot notation, an object whose
property is changing. Consider this set of operations:

```
let             test;
let             p;
const           ObservableSlim = require("./observable-slim.js");

test = {};
p = ObservableSlim.create(
  test,
  false,
  (changes) =>
    {
      console.log(JSON.stringify(changes, null, "  "));
    });

p.hello = "world";
p["a.b"] = { c : {} };
p["a.b"].c["e.f"] = 42;
```

The output of the final change is:

```
[
  {
    "type": "add",
    "target": {
      "e.f": 42
    },
    "property": "e.f",
    "newValue": 42,
    "currentPath": "a.b.c.e.f",
    "jsonPointer": "/a/b/c/e/f",
    "proxy": {
      "e.f": 42
    }
  }
]
```

Note that it is not exactly trivial to figure out how to update a remote
object based on this information. There is nothing here that would tell you
that of currentPath "a.b.c.e.f", the "a.b" part is a single key.

To help resolve this problem, I have added the parent path to the change
map. With the parent path, an array, it is easy to iterate through the array
beginning at the top-level object, to then add/update/whatever the given
property. With the change, the above test yields, as the final change, the
following, which includes the `parent` array member:

```
[
  {
    "type": "add",
    "target": {
      "e.f": 42
    },
    "parent": [
      "a.b",
      "c"
    ],
    "property": "e.f",
    "newValue": 42,
    "currentPath": "a.b.c.e.f",
    "jsonPointer": "/a/b/c/e/f",
    "proxy": {
      "e.f": 42
    }
  }
]
```