### PR TITLE
Added changes queue (batch style transactions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .nyc_output
 coverage
+yarn.lock

--- a/observable-slim.js
+++ b/observable-slim.js
@@ -710,7 +710,7 @@ var ObservableSlim = (function() {
 					observables[i].queueChanges = false;
 					foundMatch = true;
 
-					if (observables[i].changesQueue !== []) {
+					if (observables[i].changesQueue.length > 0) {
 						var changesCopy = observables[i].changesQueue.slice(0); // same copy as _notifyObserver so we ensure queue gets emptied
 						observables[i].changesQueue = [];
 

--- a/observable-slim.js
+++ b/observable-slim.js
@@ -727,6 +727,47 @@ var ObservableSlim = (function() {
 			if (foundMatch == false) throw new Error("ObseravableSlim could not flush changes-- matching proxy not found.");
 		},
 
+		/*	Method: clearChanges
+				This method will clear existing change notifications
+
+			Parameters:
+				proxy 	- the ES6 Proxy returned by the create() method.
+		*/
+		clearChanges: function(proxy) {
+			var i = observables.length;
+			var foundMatch = false;
+			while (i--) {
+				if (observables[i].parentProxy === proxy) {
+					foundMatch = true;
+					observables[i].changesQueue = [];
+					break;
+				}
+			};
+
+			if (foundMatch == false) throw new Error("ObseravableSlim could not clear change queue -- matching proxy not found.");
+		},
+
+		/*	Method: cancelChanges
+				This method will cancel any pending change notifications
+
+			Parameters:
+				proxy 	- the ES6 Proxy returned by the create() method.
+		*/
+		cancelChanges: function(proxy) {
+			var i = observables.length;
+			var foundMatch = false;
+			while (i--) {
+				if (observables[i].parentProxy === proxy) {
+					foundMatch = true;
+					observables[i].queueChanges = false;
+					observables[i].changesQueue = [];
+					break;
+				}
+			};
+
+			if (foundMatch == false) throw new Error("ObseravableSlim could not cancel change queue -- matching proxy not found.");
+		},
+
 		/*	Method: remove
 				This method will remove the observable and proxy thereby preventing any further callback observers for
 				changes occuring to the target object.

--- a/observable-slim.js
+++ b/observable-slim.js
@@ -686,8 +686,9 @@ var ObservableSlim = (function() {
 			var foundMatch = false;
 			while (i--) {
 				if (observables[i].parentProxy === proxy) {
-					observables[i].queueChanges = true;
 					foundMatch = true;
+					observables[i].queueChanges = true;
+					observables[i].changesQueue = [];
 					break;
 				}
 			};
@@ -707,8 +708,18 @@ var ObservableSlim = (function() {
 			while (i--) {
 				if (observables[i].parentProxy === proxy) {
 					observables[i].queueChanges = false;
-					observables[i].observers.forEach(o => o(observables[i].changesQueue))
 					foundMatch = true;
+
+					if (observables[i].changesQueue !== []) {
+						var changesCopy = observables[i].changesQueue.slice(0); // same copy as _notifyObserver so we ensure queue gets emptied
+						observables[i].changesQueue = [];
+
+						observables[i].observers
+							.forEach(function(observer){
+								observer(changesCopy)
+							})
+					}
+
 					break;
 				}
 			};

--- a/test/test.js
+++ b/test/test.js
@@ -827,7 +827,7 @@ function suite(proxy) {
 		ObservableSlim.queueChanges(p)
 		ObservableSlim.flushChanges(p)
 
-		assert(function() { ObservableSlim.clearChanges({}); }, Error, "ObseravableSlim could not clear changes-- matching proxy not found.");
+		assert(function() { ObservableSlim.clearChanges({}); }, Error, "ObseravableSlim could not clear changes -- matching proxy not found.");
 
 		expect(callbackCount).to.equal(0);
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -776,5 +776,79 @@ function suite(proxy) {
 		}
 		
 	});
-	
+
+	it('42. Verify changes queue works as expected.', () => {
+		var callbackCount = 0;
+		
+		var data = {
+			num: 0,
+			arr: [],			
+		}
+
+		var p = ObservableSlim.create(data, false, function(changes) {
+			callbackCount++;
+		})
+
+		ObservableSlim.queueChanges(p)
+		p.num++
+		p.arr.push({
+			test:p.num,
+		})
+		ObservableSlim.flushChanges(p)
+
+		expect(callbackCount).to.equal(1);
+	});
+
+	it('43. Verify that queueChanges and clearChanges both reset change number and fail to call observers', () => {
+		var callbackCount = 0;
+		
+		var data = {
+			num: 0,
+			arr: [],			
+		}
+		var p = ObservableSlim.create(data, false, function(changes) {
+			callbackCount++;
+		})
+
+		ObservableSlim.queueChanges(p)
+		p.arr.push({
+			test:p.num++,
+		})
+		ObservableSlim.clearChanges(p)
+		ObservableSlim.flushChanges(p)
+
+		ObservableSlim.queueChanges(p)
+		p.arr.push({
+			test:p.num++,
+		})
+		ObservableSlim.queueChanges(p)
+		ObservableSlim.flushChanges(p)
+
+		expect(callbackCount).to.equal(0);
+	});
+
+	it('44. Verify that cancelChanges stops queuing changes', () => {
+		var callbackCount = 0;
+		
+		var data = {
+			num: 0,
+			arr: [],			
+		}
+
+		var p = ObservableSlim.create(data, false, function(changes) {
+			callbackCount++;
+		})
+
+		ObservableSlim.queueChanges(p)
+		p.arr.push({
+			test:p.num++,
+		})
+		ObservableSlim.cancelChanges(p)
+		p.arr.push({
+			test:p.num++,
+		})
+		ObservableSlim.flushChanges(p)
+
+		expect(callbackCount).to.be.above(1);
+	})	
 };


### PR DESCRIPTION
This is a resubmit using proper practices (dedicated branch).

I've added two primary ObservableSlim functions.  `queueChanges` and `flushChanges`.  They came from the idea of a `BeginTransaction` and an `EndTransaction`

I've also added `clearChanges` and `cancelChanges` for utility.

In summary, when queuing, `_notifyObserver` will append/concat the changes to a queue and delay notifying the `observers`.  When you flush the changes, all the queued changes get sent to the observers as one `changes` style object.

Here's an example in nodejs
``` javascript
var ObservableSlim = require("observable-slim")

var model = {
    Hello: "World",
    test: [],
    num: 0,
    nesty: {
        arr: []
    }
}

var dataModel = ObservableSlim.create(model, true, function (changes) {
    console.log(changes);
})

var test = dataModel.nesty.arr
ObservableSlim.queueChanges(dataModel)
test.push({
    Anything: dataModel.num++,
});
dataModel.test.push({
    first: dataModel.num++,
})
ObservableSlim.flushChanges(dataModel)

console.log('done');

```


_Without_ the queue, the output would look like this:
``` javascript
> (2) [{…}, {…}]
> (2) [{…}, {…}]
> (2) [{…}, {…}]
```

**With** the queue, the output looks like this:
```javascript
> (6) [{…}, {…}, {…}, {…}, {…}, {…}]
```

This also includes test cases that should cover all my code.

Thanks!
Nathan