### PR TITLE
Prevent internal __length property from being enumerable

### DIFF
--- a/observable-slim.js
+++ b/observable-slim.js
@@ -61,8 +61,13 @@ var ObservableSlim = (function() {
 		// in order to accurately report the "previous value" of the "length" property on an Array
 		// we must use a helper property because intercepting a length change is not always possible as of 8/13/2018 in 
 		// Chrome -- the new `length` value is already set by the time the `set` handler is invoked
-		if (target instanceof Array) target.__length = target.length;
-		
+		if (target instanceof Array) {
+			if (!target.hasOwnProperty("__length"))
+				Object.defineProperty(target, "__length", { enumerable: false, value: target.length, writable: true });
+			else
+				target.__length = target.length;
+			}
+
 		var changes = [];
 
 		/*	Function: _getPath

--- a/test/test.js
+++ b/test/test.js
@@ -774,7 +774,23 @@ function suite(proxy) {
 			expect(p.test.deeper.__getPath).to.equal("test.deeper");
 			expect(p.arr[0].test.__getPath).to.equal("arr.0.test");
 		}
-		
+
+	});
+
+	it('42. Array does not enumerate __length.', () => {
+		var largeArray = [];
+
+		for (var i = 0; i < 5; i++) {
+			largeArray.push({
+				"hello":"world"
+				,"foo":"bar"
+			});
+		}
+
+		var proxyArr = ObservableSlim.create(largeArray, false, function(changes) {});
+
+		var keys = Array.from(proxyArr.keys());
+		expect(keys.every(item => !Number.isNaN(item))).to.be.true;
 	});
 	
 };


### PR DESCRIPTION
This change is to resolve https://github.com/ElliotNB/observable-slim/issues/43. 
By defining `__length` property to be both immutable and not enumerable, as suggested in the issue comments.  This resolved a similar issue I encountered when looping observed arrays.

A unit test has also been added to verify that only array indices are enumerable now.